### PR TITLE
Feature/fix bh issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ doc02_key = bh.add_document_by_b64(filename, pdf_b64)
 
 # 3) Add a document that you have already read into a Python bytearray object
 filename, pdf_bytearray = read_a_file_into_bytearray()
-doc03_key = bh.add_document_by_bytearray(pdf_bytearray, filename)
+doc03_key = bh.add_document_by_bytearray(filename, pdf_bytearray)
 
 # 4) Add a document as a File object. Make sure to use 'with' or suitably close the file
 #    after creating the document.

--- a/src/blueink/bundle_helper.py
+++ b/src/blueink/bundle_helper.py
@@ -128,7 +128,7 @@ class BundleHelper:
         return document.key
 
     def add_document_by_bytearray(
-        self, byte_array: bytearray, filename: str, **additional_data
+        self, filename: str, byte_array: bytearray, **additional_data
     ) -> str:
         """Add a file using a python bytearray object
 

--- a/src/blueink/request_helper.py
+++ b/src/blueink/request_helper.py
@@ -1,6 +1,5 @@
 import requests
 from munch import munchify
-from requests import Request, Session
 
 from blueink.constants import BLUEINK_PAGINATION_HEADER
 
@@ -120,6 +119,5 @@ class RequestHelper:
         )
 
         if self._raise_exceptions:
-            # print(response.content)
             response.raise_for_status()
         return NormalizedResponse(response)


### PR DESCRIPTION
I was unable to replicate the issue. Instead I fixed some inconsistent parameter ordering. Test script successfully creates a bundle with documents added by each method

```
from pprint import pprint
from blueink import Client, BundleHelper, constants
from blueink.request_helper import NormalizedResponse
from base64 import b64encode

cl = Client()

bh = BundleHelper(
    label="MyAPITestBundle",
    email_subject="Hello Mr Bundle",
    email_message="Your Bundle has arrived!",
    in_order=False,
    is_test=True,
)

doc1 = bh.add_document_by_path("fw4.pdf")

doc2 = bh.add_document_by_url("https://www.irs.gov/pub/irs-pdf/fw4.pdf")

with open("fw4.pdf", "rb") as file:
    bytes = file.read()
    doc3 = bh.add_document_by_bytearray(
        byte_array=bytes, 
        filename="fw4-bytes.pdf", 
        mime_type="application/pdf"
    )

with open("fw4.pdf", "rb") as file:
    b64str = b64encode(file.read()).decode("utf-8")
    doc4 = bh.add_document_by_b64(
        filename="fw4-b64.pdf", 
        b64str=b64str
    )

signer1 = bh.add_signer(
    name="Joe Schmoe", 
    email="Joe@example.com",
    deliver_via=constants.DELIVER_VIA.EMAIL,
)

field1 = bh.add_field(
    document_key=doc1,
    x=20,
    y=20,
    w=5,
    h=2,
    p=1,
    kind=constants.FIELD_KIND.INPUT,
    label="MyTestField",
    editors=[signer1]
)

resp: NormalizedResponse = cl.bundles.create_from_bundle_helper(bh)
print(resp.status)
pprint(resp.data)
```